### PR TITLE
Implement password reset workflow

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -23,6 +23,7 @@
     "dotenv": "^16.3.1",
     "express-rate-limit": "^7.1.5",
     "express-validator": "^7.0.1"
+    , "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -15,8 +15,10 @@
 import express from 'express';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 import { body, validationResult } from 'express-validator';
 import { authenticateToken } from '../middleware/auth';
+import { sendPasswordResetEmail } from '../utils/email';
 
 const router = express.Router();
 
@@ -35,6 +37,8 @@ interface User {
     highScore: number;
     totalScore: number;
   };
+  resetToken?: string;
+  resetTokenExpiry?: Date;
 }
 
 const users: User[] = [];
@@ -207,6 +211,61 @@ router.get('/me', authenticateToken, (req, res) => {
       message: 'Failed to fetch user profile'
     });
   }
+});
+
+/**
+ * POST /api/auth/forgot-password
+ * Initiate password reset process
+ */
+router.post('/forgot-password', [body('email').isEmail().normalizeEmail()], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ error: 'Validation failed', details: errors.array() });
+  }
+
+  const { email } = req.body;
+  const user = users.find(u => u.email === email);
+
+  if (user) {
+    const token = crypto.randomBytes(32).toString('hex');
+    user.resetToken = token;
+    user.resetTokenExpiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+    try {
+      await sendPasswordResetEmail(email, token);
+    } catch (err) {
+      console.error('Failed to send reset email:', err);
+    }
+  }
+
+  res.json({ message: 'If the email exists, a reset link has been sent.' });
+});
+
+/**
+ * POST /api/auth/reset-password
+ * Complete password reset
+ */
+router.post('/reset-password', [
+  body('token').exists(),
+  body('password').isLength({ min: 6 })
+], async (req, res) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({ error: 'Validation failed', details: errors.array() });
+  }
+
+  const { token, password } = req.body;
+  const user = users.find(u => u.resetToken === token && u.resetTokenExpiry && u.resetTokenExpiry > new Date());
+
+  if (!user) {
+    return res.status(400).json({ error: 'Invalid or expired token' });
+  }
+
+  const hashedPassword = await bcrypt.hash(password, 12);
+  user.password = hashedPassword;
+  user.resetToken = undefined;
+  user.resetTokenExpiry = undefined;
+
+  res.json({ message: 'Password reset successful' });
 });
 
 /**

--- a/backend/src/utils/email.ts
+++ b/backend/src/utils/email.ts
@@ -1,0 +1,24 @@
+import nodemailer from 'nodemailer';
+
+export const sendPasswordResetEmail = async (to: string, token: string) => {
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT || '587', 10),
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+
+  const resetUrl = `${process.env.FRONTEND_URL || 'http://localhost:5173'}/reset-password?token=${token}`;
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM || 'no-reply@example.com',
+    to,
+    subject: 'Password Reset',
+    text: `Reset your password: ${resetUrl}`,
+    html: `<p>Click <a href="${resetUrl}">here</a> to reset your password.</p>`
+  });
+};
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import Home from "./pages/Home";
 import Game from "./pages/Game";
 import Leaderboard from "./pages/Leaderboard";
 import Login from "./pages/Login";
+import ForgotPassword from "./pages/ForgotPassword";
+import ResetPassword from "./pages/ResetPassword";
 import Profile from "./pages/Profile";
 import BackendTest from "./pages/BackendTest";
 import NotFound from "./pages/NotFound";
@@ -23,6 +25,8 @@ const App = () => (
           <Route path="/game" element={<Game />} />
           <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/login" element={<Login />} />
+          <Route path="/forgot-password" element={<ForgotPassword />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/backend-test" element={<BackendTest />} />
           <Route path="*" element={<NotFound />} />

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Container, Row, Col, Card, Form, Button, Alert } from 'react-bootstrap';
+import Navigation from '../components/Navigation';
+
+const ForgotPassword: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setMessage(null);
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to request reset');
+      setMessage(data.message || 'Check your email for further instructions');
+      setEmail('');
+    } catch (err: any) {
+      setError(err.message || 'Failed to request reset');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Navigation />
+      <Container>
+        <Row className="justify-content-center">
+          <Col md={6} lg={5}>
+            <Card>
+              <Card.Header>
+                <h4 className="mb-0 text-center">Forgot Password</h4>
+              </Card.Header>
+              <Card.Body>
+                {message && <Alert variant="success">{message}</Alert>}
+                {error && <Alert variant="danger">{error}</Alert>}
+                <Form onSubmit={handleSubmit}>
+                  <Form.Group className="mb-3">
+                    <Form.Label>Email</Form.Label>
+                    <Form.Control
+                      type="email"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      required
+                    />
+                  </Form.Group>
+                  <Button type="submit" variant="primary" className="w-100" disabled={loading}>
+                    {loading ? 'Loading...' : 'Send Reset Link'}
+                  </Button>
+                </Form>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      </Container>
+    </>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -218,6 +218,11 @@ const Login: React.FC = () => {
                     {loading ? 'Loading...' : (isRegister ? 'Join the Battle' : 'Enter the Battle')}
                   </Button>
                 </Form>
+                {!isRegister && (
+                  <div className="text-center mb-3">
+                    <a href="/forgot-password">Forgot your password?</a>
+                  </div>
+                )}
                 
                 <div className="text-center">
                   <Button

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import { Container, Row, Col, Card, Form, Button, Alert } from 'react-bootstrap';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import Navigation from '../components/Navigation';
+
+const ResetPassword: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const token = searchParams.get('token');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  if (!token) {
+    return (
+      <>
+        <Navigation />
+        <Container className="pt-5">
+          <Alert variant="danger">Invalid password reset link.</Alert>
+        </Container>
+      </>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setMessage(null);
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    setLoading(true);
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, password })
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to reset password');
+      setMessage(data.message || 'Password reset successful');
+      setTimeout(() => navigate('/login'), 1500);
+    } catch (err: any) {
+      setError(err.message || 'Failed to reset password');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Navigation />
+      <Container>
+        <Row className="justify-content-center">
+          <Col md={6} lg={5}>
+            <Card>
+              <Card.Header>
+                <h4 className="mb-0 text-center">Reset Password</h4>
+              </Card.Header>
+              <Card.Body>
+                {message && <Alert variant="success">{message}</Alert>}
+                {error && <Alert variant="danger">{error}</Alert>}
+                <Form onSubmit={handleSubmit}>
+                  <Form.Group className="mb-3">
+                    <Form.Label>New Password</Form.Label>
+                    <Form.Control
+                      type="password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                    />
+                  </Form.Group>
+                  <Form.Group className="mb-3">
+                    <Form.Label>Confirm Password</Form.Label>
+                    <Form.Control
+                      type="password"
+                      value={confirm}
+                      onChange={(e) => setConfirm(e.target.value)}
+                      required
+                    />
+                  </Form.Group>
+                  <Button type="submit" variant="primary" className="w-100" disabled={loading}>
+                    {loading ? 'Loading...' : 'Reset Password'}
+                  </Button>
+                </Form>
+              </Card.Body>
+            </Card>
+          </Col>
+        </Row>
+      </Container>
+    </>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
## Summary
- add nodemailer mailer helper
- add forgot-password and reset-password endpoints
- create ForgotPassword and ResetPassword pages
- register new routes and link from login page

## Testing
- `npm run lint` *(fails: Unexpected any, etc.)*
- `npx tsc` *(fails: cannot find module / implicit any errors)*
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_6862c1b29d84832db7cc8faffa63e24b