### PR TITLE
Load Supabase settings from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example Supabase configuration
+SUPABASE_URL=https://your-supabase-instance.supabase.co
+SUPABASE_PUBLISHABLE_KEY=your-anon-key

--- a/README.md
+++ b/README.md
@@ -110,11 +110,18 @@ cd bootstrap-vs-zombies
 # Install dependencies
 npm install
 
+# Copy environment example and add your Supabase credentials
+cp .env.example .env
+
 # Start development server
 npm run dev
 
 # Open http://localhost:5173 in your browser
 ```
+
+The application expects `SUPABASE_URL` and `SUPABASE_PUBLISHABLE_KEY` to be
+present in a `.env` file. Copy `.env.example` to `.env` and fill in your
+Supabase project details before starting the server.
 
 ### Development Commands
 ```bash

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,9 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://qwedwkokcvwmzeutrygi.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF3ZWR3a29rY3Z3bXpldXRyeWdpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzNTUzMTUsImV4cCI6MjA2NTkzMTMxNX0.4exGVSL4bzbwf9QqgjP3IFXfufA_1pl5Jc2nGrW58lc";
+// Read configuration from the Vite environment.
+const SUPABASE_URL = import.meta.env.SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.SUPABASE_PUBLISHABLE_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => ({
     host: "::",
     port: 8080,
   },
+  envPrefix: ["VITE_", "SUPABASE_"],
   plugins: [
     react(),
     mode === 'development' &&


### PR DESCRIPTION
## Summary
- use `import.meta.env` for Supabase credentials
- allow `SUPABASE_*` variables in Vite
- provide `.env.example`
- mention env setup in README

## Testing
- `npm run lint` *(fails: unexpected any and other lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_6862c3aa0804832da27e0ea22e708656