### PR TITLE
Add Docker setup and deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,34 @@ We welcome contributions that enhance the educational value of the project!
 4. Test thoroughly (both educational and technical aspects)
 5. Submit a pull request with detailed description
 
+## 🚀 Deployment
+
+The project includes Docker configuration for running the React frontend and Flask backend.
+
+### Local development
+
+1. Build the Docker images and start the stack:
+   ```bash
+   docker compose up --build
+   ```
+2. Access the frontend at [http://localhost:5173](http://localhost:5173) and the API at [http://localhost:5000](http://localhost:5000).
+
+### Deploying to Render
+
+1. Create a new **Web Service** on Render and point it to the `backend/` directory. Render will build the image from `backend/Dockerfile`.
+2. Create a **Static Site** for the React frontend. Set the build command to `npm run build` and the publish directory to `dist`.
+3. Configure environment variables (e.g., database URLs) on each service as needed.
+
+### Deploying to Heroku
+
+1. Install the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) and log in.
+2. Use Heroku's container registry to deploy the backend:
+   ```bash
+   heroku container:push web -a your-backend-app -R backend
+   heroku container:release web -a your-backend-app
+   ```
+3. For the frontend, create a separate app using the Node buildpack. Set `heroku-postbuild` to `npm run build` and serve the static files with a simple server such as `serve` or `vite preview`.
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,19 @@
+# Use official Python runtime as a parent image
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port for Flask
+ENV PORT=5000
+EXPOSE $PORT
+
+# Run the application
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "app:app"]

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,12 @@
+from flask import Flask, jsonify
+import os
+
+app = Flask(__name__)
+
+@app.route('/health')
+def health():
+    return jsonify(status='OK', message='Bootstrap vs Zombies Flask backend running')
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask==3.0.3
+gunicorn==21.2.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+services:
+  frontend:
+    image: node:18
+    working_dir: /usr/src/app
+    volumes:
+      - .:/usr/src/app
+    command: sh -c "npm install && npm run dev"
+    ports:
+      - "5173:5173"
+    environment:
+      - PORT=5173
+    depends_on:
+      - backend
+
+  backend:
+    build: ./backend
+    ports:
+      - "5000:5000"
+    environment:
+      - PORT=5000
+    restart: always

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,19 +4,26 @@ import path from "path";
 import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' &&
-    componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const isProduction = mode === 'production';
+  return {
+    base: isProduction ? './' : '/',
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins: [
+      react(),
+      !isProduction && componentTagger(),
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: !isProduction,
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- add Flask backend Dockerfile with simple app
- provide docker-compose for frontend and backend
- document deployment steps in README
- tweak Vite config for production builds

## Testing
- `npm install`
- `npm run lint` *(fails: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_b_6862c715a300832d8000d8aa2f125014