### PR TITLE
Load supabase config from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ npm run dev
 # Open http://localhost:5173 in your browser
 ```
 
+### Environment Variables
+Create a `.env` file in the project root with your Supabase credentials:
+
+```bash
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-anon-key>
+```
+
 ### Development Commands
 ```bash
 npm run dev          # Start development server

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,10 +2,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://qwedwkokcvwmzeutrygi.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF3ZWR3a29rY3Z3bXpldXRyeWdpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzNTUzMTUsImV4cCI6MjA2NTkzMTMxNX0.4exGVSL4bzbwf9QqgjP3IFXfufA_1pl5Jc2nGrW58lc";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY);
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY);


### PR DESCRIPTION
## Summary
- reference Supabase URL and anon key from `import.meta.env`
- document `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in README

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_6862ce3de7e4832d919ec8f8e9bd313e