### PR TITLE
Add pytest tests for auth and game session endpoints

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,10 @@
+pytest
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+Flask
+Flask-JWT-Extended
+Flask-Bcrypt
+Flask-SQLAlchemy
+python-dotenv

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+import flask
+
+if not hasattr(flask.Flask, "before_first_request"):
+    def before_first_request(self, func):
+        self.before_request(func)
+        return func
+
+    flask.Flask.before_first_request = before_first_request
+
+from flask_backend.app import app, db
+
+@pytest.fixture()
+def client(tmp_path):
+    test_db = tmp_path / "test.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{test_db}"
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.environ["DATABASE_URL"]
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+    with app.app_context():
+        db.drop_all()
+
+
+def register(client, email="test@example.com", name="Tester", password="Password123"):
+    return client.post(
+        "/api/auth/register",
+        json={"email": email, "name": name, "password": password},
+    )
+
+
+def login(client, email="test@example.com", password="Password123"):
+    return client.post("/api/auth/login", json={"email": email, "password": password})
+
+
+def test_register_and_login(client):
+    response = register(client)
+    assert response.status_code == 201
+    data = response.get_json()
+    assert "token" in data
+
+    response = login(client)
+    assert response.status_code == 200
+    data = response.get_json()
+    assert "token" in data

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,34 @@
+from fastapi.testclient import TestClient
+from backend_py.main import app
+
+client = TestClient(app)
+
+def test_game_session_crud():
+    # create
+    create_resp = client.post("/sessions", json={"user_id": 1, "score": 10})
+    assert create_resp.status_code == 200
+    session_id = create_resp.json()["id"]
+
+    # list
+    list_resp = client.get("/sessions")
+    assert list_resp.status_code == 200
+    assert any(s["id"] == session_id for s in list_resp.json())
+
+    # get
+    get_resp = client.get(f"/sessions/{session_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["id"] == session_id
+
+    # update
+    update_resp = client.put(f"/sessions/{session_id}", json={"score": 50})
+    assert update_resp.status_code == 200
+    assert update_resp.json()["score"] == 50
+
+    # delete
+    delete_resp = client.delete(f"/sessions/{session_id}")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["detail"] == "Session deleted"
+
+    # confirm deletion
+    not_found_resp = client.get(f"/sessions/{session_id}")
+    assert not_found_resp.status_code == 404


### PR DESCRIPTION
## Summary
- add `requirements-test.txt` for test dependencies
- create pytest tests for Flask auth endpoints
- create pytest tests for FastAPI game session CRUD

## Testing
- `pip install -r requirements-test.txt -r backend_py/requirements.txt -r flask_backend/requirements.txt`
- `pip install 'httpx<0.28' --force-reinstall`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6862cf3af444832da89e87a1aa555092