### PR TITLE
Add httpx to test requirements

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ Flask-JWT-Extended
 Flask-Bcrypt
 Flask-SQLAlchemy
 python-dotenv
+httpx


### PR DESCRIPTION
## Summary
- add missing httpx dependency to `requirements-test.txt`

## Testing
- `pip install -q -r requirements-test.txt`
- `pytest -q` *(fails: No module named 'flask_backend')*

------
https://chatgpt.com/codex/tasks/task_b_6862e4e9b4ac832d8166f83babb1cc6c